### PR TITLE
Invalid header

### DIFF
--- a/src/composer.php
+++ b/src/composer.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -284,7 +284,7 @@ class ezcMailComposer extends ezcMail
      * Content-Disposition header set according to the $contentDisposition
      * object and the filename of the attachment in the generated mail will be
      * the one from the $contentDisposition object.
-     * 
+     *
      * @throws ezcBaseFileNotFoundException
      *         if $fileName does not exists.
      * @throws ezcBaseFilePermissionProblem
@@ -320,7 +320,7 @@ class ezcMailComposer extends ezcMail
      * Content-Disposition header set according to the $contentDisposition
      * object and the filename of the attachment in the generated mail will be
      * the one from the $contentDisposition object.
-     * 
+     *
      * @throws ezcBaseFileNotFoundException
      *         if $fileName does not exists.
      * @throws ezcBaseFilePermissionProblem
@@ -362,7 +362,7 @@ class ezcMailComposer extends ezcMail
      * Content-Disposition header set according to the $contentDisposition
      * object and the filename of the attachment in the generated mail will be
      * the one from the $contentDisposition object.
-     * 
+     *
      * @param string $fileName
      * @param string $content
      * @param string $contentType
@@ -490,10 +490,10 @@ class ezcMailComposer extends ezcMail
                         src\\s*=\\s*
                             (?:
                                 (?# Match quoted attribute)
-                                ([\'"])file://(?P<quoted>[^"]+)\\1
+                                ([\'"])notion://(?P<quoted>[^"]+)\\1
 
                                 (?# Match unquoted attribute, which may not contain spaces)
-                            |   file://(?P<unquoted>[^>\\s]+)
+                            |   notion://(?P<unquoted>[^>\\s]+)
                         )
                     [^>]* >)ix', $this->htmlText, $matches );
                 // pictures/files can be added multiple times. We only need them once.
@@ -538,7 +538,7 @@ class ezcMailComposer extends ezcMail
                         }
                         $cid = $result->addRelatedPart( $filePart );
                         // replace the original file reference with a reference to the cid
-                        $this->htmlText = str_replace( 'file://' . $fileName, 'cid:' . $cid, $this->htmlText );
+                        $this->htmlText = str_replace( 'notion://' . $fileName, 'cid:' . $cid, $this->htmlText );
                     }
                     else
                     {

--- a/src/exceptions/incomplete_header.php
+++ b/src/exceptions/incomplete_header.php
@@ -1,0 +1,3 @@
+<?php
+
+class ezcMailIncompleteHeaderException extends ezcMailException {}

--- a/src/exceptions/invalid_mime.php
+++ b/src/exceptions/invalid_mime.php
@@ -1,0 +1,3 @@
+<?php
+
+class ezcMailInvalidMimeException extends ezcMailException {}

--- a/src/internal/charset_convert.php
+++ b/src/internal/charset_convert.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -135,11 +135,7 @@ class ezcMailCharsetConverter
      */
     public static function convertToUTF8Iconv( $text, $originalCharset )
     {
-        if ( $originalCharset === 'unknown-8bit' || $originalCharset === 'x-user-defined' )
-        {
-            $originalCharset = "latin1";
-        }
-        return iconv( $originalCharset, 'utf-8', $text );
+        return \Notion\Common\Str::convert_charset_to_utf8($originalCharset, $text);
     }
 }
 ?>

--- a/src/mail.php
+++ b/src/mail.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -379,7 +379,7 @@ class ezcMail extends ezcMailPart
         $this->setHeader( 'Subject', $this->subject, $this->subjectCharset );
 
         $this->setHeader( 'MIME-Version', '1.0' );
-        $this->setHeader( 'User-Agent', 'Apache Zeta Components' );
+        $this->setHeader('User-Agent', 'Notion Mail ' . date('Y-m-d'));
         $this->setHeader( 'Date', date( 'r' ) );
         $idhost = $this->from != null && $this->from->email != '' ? $this->from->email : 'localhost';
         if ( is_null( $this->messageId ) )

--- a/src/mail.php
+++ b/src/mail.php
@@ -498,7 +498,7 @@ class ezcMail extends ezcMailPart
                 break;
 
             case 'ezcMailMultipartRelated':
-                if ($mail->getMainPart())
+                if (!$mail->getMainPart())
                     throw new ezcMailInvalidMimeException('Unable to parse invalid mime message multipart/related');
 
                 $this->walkParts( $context, $mail->getMainPart() );

--- a/src/mail.php
+++ b/src/mail.php
@@ -498,6 +498,9 @@ class ezcMail extends ezcMailPart
                 break;
 
             case 'ezcMailMultipartRelated':
+                if ($mail->getMainPart())
+                    throw new ezcMailInvalidMimeException('Unable to parse invalid mime message multipart/related');
+
                 $this->walkParts( $context, $mail->getMainPart() );
                 foreach ( $mail->getRelatedParts() as $part )
                 {

--- a/src/mail.php
+++ b/src/mail.php
@@ -379,7 +379,7 @@ class ezcMail extends ezcMailPart
         $this->setHeader( 'Subject', $this->subject, $this->subjectCharset );
 
         $this->setHeader( 'MIME-Version', '1.0' );
-        $this->setHeader('User-Agent', 'Notion Mail ' . date('Y-m-d'));
+        $this->setHeader('User-Agent', 'Notion Mail');
         $this->setHeader( 'Date', date( 'r' ) );
         $idhost = $this->from != null && $this->from->email != '' ? $this->from->email : 'localhost';
         if ( is_null( $this->messageId ) )

--- a/src/mail_autoload.php
+++ b/src/mail_autoload.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -28,6 +28,7 @@
 return array(
     'ezcMailException'                  => 'Mail/exceptions/mail_exception.php',
     'ezcMailInvalidLimitException'      => 'Mail/exceptions/invalid_limit.php',
+    'ezcMailIncompleteHeaderException'  => 'Mail/exceptions/incomplete_header.php',
     'ezcMailNoSuchMessageException'     => 'Mail/exceptions/no_such_message.php',
     'ezcMailOffsetOutOfRangeException'  => 'Mail/exceptions/offset_out_of_range.php',
     'ezcMailTransportException'         => 'Mail/exceptions/transport_exception.php',

--- a/src/parser/interfaces/part_parser.php
+++ b/src/parser/interfaces/part_parser.php
@@ -245,6 +245,8 @@ abstract class ezcMailPartParser
             if ( !in_array( strtolower( $this->lastParsedHeader ), self::$uniqueHeaders ) )
             {
                 $arr = $headers[$this->lastParsedHeader];
+                if (!isset($arr[0]))
+                    throw new \ezcMailIncompleteHeaderException('Line ' . $line . ' is an incomplete header and cannot be parsed');
                 $arr[0][count( $arr[0] ) - 1] .= ' ' . ltrim(str_replace( "\t", " ", $line ), ' ');
                 $headers[$this->lastParsedHeader] = $arr;
             }

--- a/src/parser/interfaces/part_parser.php
+++ b/src/parser/interfaces/part_parser.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -245,12 +245,12 @@ abstract class ezcMailPartParser
             if ( !in_array( strtolower( $this->lastParsedHeader ), self::$uniqueHeaders ) )
             {
                 $arr = $headers[$this->lastParsedHeader];
-                $arr[0][count( $arr[0] ) - 1] .= str_replace( "\t", " ", $line );
+                $arr[0][count( $arr[0] ) - 1] .= ' ' . ltrim(str_replace( "\t", " ", $line ), ' ');
                 $headers[$this->lastParsedHeader] = $arr;
             }
             else
             {
-                $headers[$this->lastParsedHeader] .= str_replace( "\t", " ", $line );
+                $headers[$this->lastParsedHeader] .= ' ' . ltrim(str_replace( "\t", " ", $line ), ' ');
             }
         }
         // else -invalid syntax, this should never happen.

--- a/src/parser/parts/delivery_status_parser.php
+++ b/src/parser/parts/delivery_status_parser.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -106,13 +106,14 @@ class ezcMailDeliveryStatusParser extends ezcMailPartParser
             $this->part->createRecipient();
             return;
         }
-        if ( $this->section == 0 )
+        if (isset( $this->lastParsedHeader ) && $this->section == 0 )
         {
             $this->part->message[$this->lastParsedHeader] = $this->headerValue;
         }
         else
         {
-            $this->part->recipients[$this->section - 1][$this->lastParsedHeader] = $this->headerValue;
+            if (isset( $this->lastParsedHeader ))
+                $this->part->recipients[$this->section - 1][$this->lastParsedHeader] = $this->headerValue;
         }
     }
 

--- a/src/parser/parts/file_parser.php
+++ b/src/parser/parts/file_parser.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -253,7 +253,11 @@ class ezcMailFileParser extends ezcMailPartParser
                 $this->dataWritten = true;
             }
 
-            fwrite( $this->fp, $line );
+            try
+            {
+                fwrite( $this->fp, $line );
+            }
+            catch (\Exception $e) {}
         }
     }
 

--- a/src/parser/parts/file_parser.php
+++ b/src/parser/parts/file_parser.php
@@ -131,7 +131,9 @@ class ezcMailFileParser extends ezcMailPartParser
         {
             $fileName = trim( $matches[1], '"' );
         }
-        else // default
+
+        // default
+        if (empty($fileName))
         {
             $fileName = "filename";
         }

--- a/src/parser/rfc2231_implementation.php
+++ b/src/parser/rfc2231_implementation.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -100,7 +100,16 @@ class ezcMailRfc2231Implementation
                 $charset = null;
                 if ( $parts[0]['encoding'] == true )
                 {
-                    preg_match( "/(\S*)'(\S*)'(.*)/", $parts[0]['value'], $matches );
+                    if (!preg_match( "/(\S*)'(\S*)'(.*)/", $parts[0]['value'], $matches))
+                    {
+                        $matches = [
+                            null,
+                            'us-ascii',
+                            'en-us',
+                            $parts[0]['value']
+                        ];
+                    }
+
                     $charset = $matches[1];
                     $language = $matches[2];
                     $parts[0]['value'] = urldecode( $matches[3] ); // rewrite value: todo: decoding
@@ -170,7 +179,7 @@ class ezcMailRfc2231Implementation
                         {
                             $cd->displayFileName = ezcMailTools::mimeDecode( $cd->displayFileName );
                         }
- 
+
                         if ( isset( $data['language'] ) )
                         {
                             $cd->fileNameLanguage = $data['language'];

--- a/src/parser/rfc2231_implementation.php
+++ b/src/parser/rfc2231_implementation.php
@@ -98,7 +98,7 @@ class ezcMailRfc2231Implementation
                 // syntax: '[charset]'[language]'encoded_string
                 $language = null;
                 $charset = null;
-                if ( $parts[0]['encoding'] == true )
+                if ( reset($parts)['encoding'] == true )
                 {
                     if (!preg_match( "/(\S*)'(\S*)'(.*)/", $parts[0]['value'], $matches))
                     {
@@ -106,13 +106,13 @@ class ezcMailRfc2231Implementation
                             null,
                             'us-ascii',
                             'en-us',
-                            $parts[0]['value']
+                            reset($parts)['value']
                         ];
                     }
 
                     $charset = $matches[1];
                     $language = $matches[2];
-                    $parts[0]['value'] = urldecode( $matches[3] ); // rewrite value: todo: decoding
+                    reset($parts)['value'] = urldecode( $matches[3] ); // rewrite value: todo: decoding
                     $result[1][$paramName] = array( 'value' => $parts[0]['value'] );
                 }
 

--- a/src/tools.php
+++ b/src/tools.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -605,7 +605,11 @@ class ezcMailTools
 
         // Try it as latin 1 string
         $text = preg_replace( '/=\?([^?]+)\?/', '=?iso-8859-1?', $origtext );
-        $text = iconv_mime_decode( $text, 0, $charset );
+        $result = @iconv_mime_decode( $text, 0, $charset );
+        if ($result)
+        {
+            return $result;
+        }
 
         return $text;
     }
@@ -758,7 +762,7 @@ class ezcMailTools
      * $contentIdArray = array( 'consoletools-table.png@1421450' => 'http://localhost/consoletools-table.jpg' );
      * $text = "<html> Embedded image: <img src='cid:consoletools-table.png@1421450'/> </html>";
      * $htmlBody = ezcMailTools::replaceContentIdRefs( $text, $contentIdArray );
-     * // $htmlBody is now: 
+     * // $htmlBody is now:
      * // <html> Embedded image: <img src='http://localhost/consoletools-table.jpg'/> </html>
      * ?>
      * </code>

--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -621,7 +621,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
         // setup TLS connection before continuing with AUTH
         if ( $this->options->connectionType == 'tls' )
         {
-            if ( !preg_match( "/250-STARTTLS/", $response) )
+            if ( !preg_match( "/250[- ]STARTTLS/", $response) )
             {
                 throw new ezcMailTransportSmtpException( 'SMTP server does not accept the STARTTLS command.' );
             }

--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -9,9 +9,9 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- * 
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -519,9 +519,9 @@ class ezcMailSmtpTransport implements ezcMailTransport
             $this->sendData( $data );
             $this->sendData( '.' );
 
-            if ( $this->getReplyCode( $error ) !== '250' )
+            if ( $this->getReplyCode( $line ) !== '250' )
             {
-                throw new ezcMailTransportSmtpException( "Error: {$error}" );
+                throw new ezcMailTransportSmtpException(trim($line));
             }
         }
         catch ( ezcMailTransportSmtpException $e )
@@ -542,6 +542,8 @@ class ezcMailSmtpTransport implements ezcMailTransport
                 // Eat! We don't care anyway since we are aborting the connection
             }
         }
+
+         return trim($line);
     }
 
     /**
@@ -590,7 +592,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
         }
         else
         {
-            throw new ezcMailTransportSmtpException( "Failed to connect to the smtp server: {$this->serverHost}:{$this->serverPort}." );
+            throw new ezcMailTransportSmtpException( "Failed to connect to the smtp server: {$this->serverHost}:{$this->serverPort}" );
         }
     }
 
@@ -963,7 +965,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
         {
             throw new ezcMailTransportSmtpException( 'SMTP server did not allow NTLM authentication.' );
         }
-        
+
         return true;
     }
 
@@ -1315,7 +1317,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
         $td = mcrypt_module_open( 'des', '', 'ecb', '' );
         $iv = mcrypt_create_iv( mcrypt_enc_get_iv_size( $td ), MCRYPT_RAND );
 
-        $response = '';        
+        $response = '';
         for ( $i = 0; $i < 21; $i += 7 )
         {
             $packed = '';


### PR DESCRIPTION
This PR proposes a fix to https://github.com/notion/notion-cloud/issues/2138. It might be correct to throw an `ezcMailIncompleteHeaderException` or `ezcMailException` here, but looking at the logic it looks like it's possible for `$parts[0]` to not be set if we have folding. If that's what the problem is the fix might be mergeable upstream?