### PR TITLE
allow missing trailing boundary to gracefully continue

### DIFF
--- a/src/parser/parts/multipart_parser.php
+++ b/src/parser/parts/multipart_parser.php
@@ -216,6 +216,9 @@ abstract class ezcMailMultipartParser extends ezcMailPartParser
             if ( $this->currentPartParser !== null )
             {
                 $part = $this->currentPartParser->finish();
+				if (empty($part)) {
+					$part = new ezcMailMultipartMixed([]);
+				}
                 $this->partDone( $part );
                 $this->currentPartParser = null;
             }

--- a/src/parser/parts/multipart_parser.php
+++ b/src/parser/parts/multipart_parser.php
@@ -216,9 +216,9 @@ abstract class ezcMailMultipartParser extends ezcMailPartParser
             if ( $this->currentPartParser !== null )
             {
                 $part = $this->currentPartParser->finish();
-				if (empty($part)) {
-					$part = new ezcMailMultipartMixed([]);
-				}
+                if (empty($part)) {
+                    $part = new ezcMailMultipartMixed([]);
+                }
                 $this->partDone( $part );
                 $this->currentPartParser = null;
             }


### PR DESCRIPTION
A missing trailing email message boundary can cause a failure. This PR allows the parser to continue gracefully.